### PR TITLE
Add a custom icon to all trackers

### DIFF
--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -93,13 +93,14 @@ class main_listener implements EventSubscriberInterface
 	 */
 	public function page_header()
 	{
-		$sql = 'SELECT tracker_id, tracker_name
+		$sql = 'SELECT tracker_id, tracker_name, tracker_icon
 			FROM ' . $this->table_prefix . 'trackers_trackers';
 		$result = $this->db->sql_query($sql);
 		while ($row = $this->db->sql_fetchrow($result))
 		{
 			$this->template->assign_block_vars('trackers', [
 				'TRACKER_NAME'	=> $this->language->lang($row['tracker_name']),
+				'TRACKER_ICON'	=> $row['tracker_icon'],
 				'U_VIEWTRACKER'	=> $this->helper->route('phpbbmodders_trackers_controller', ['page' => 'viewtracker', 't' => (int) $row['tracker_id']]),
 			]);
 		}

--- a/language/en/common.php
+++ b/language/en/common.php
@@ -93,8 +93,8 @@ $lang = array_merge($lang, [
 	'WILL_NOT_FIX_EXPLAIN'		=> 'A developer has reviewed your report and determined the issue to be nonessential. A patch will not be provided at this time. If you believe the issue to be critical, please reply to the report with a concise argument. If you have a working patch, now is an excellent time to provide it. Further information may be available in a response to your report.',
 
 	// Trackers
-	'BUG_TRACKER'		=> 'Bug tracker',
-	'FEATURE_TRACKER'	=> 'Feature tracker',
-	'INCIDENT_TRACKER'	=> 'Incident tracker',
-	'SECURITY_TRACKER'	=> 'Security tracker',
+	'BUG_TRACKER'		=> 'Bug Tracker',
+	'FEATURE_TRACKER'	=> 'Feature Tracker',
+	'INCIDENT_TRACKER'	=> 'Incident Tracker',
+	'SECURITY_TRACKER'	=> 'Security Tracker',
 ]);

--- a/migrations/v10x/m1_initial_schema.php
+++ b/migrations/v10x/m1_initial_schema.php
@@ -188,6 +188,7 @@ class m1_initial_schema extends \phpbb\db\migration\migration
 					'COLUMNS'		=> [
 						'tracker_id'			=> ['UINT', null, 'auto_increment'],
 						'tracker_name'			=> ['VCHAR:255', ''],
+						'tracker_icon'			=> ['VCHAR:50', ''],
 						'tracker_email'			=> ['VCHAR:255', ''],
 						'tracker_visibility'	=> ['BOOL', 0],
 						'tracker_status'		=> ['BOOL', 0],

--- a/migrations/v10x/m2_initial_data.php
+++ b/migrations/v10x/m2_initial_data.php
@@ -708,6 +708,7 @@ class m2_initial_data extends \phpbb\db\migration\migration
 			[
 				'tracker_id'			=> 1,
 				'tracker_name'			=> 'INCIDENT_TRACKER',
+				'tracker_icon'			=> 'life-ring',
 				'tracker_email'			=> '',
 				'tracker_visibility'	=> 1,
 				'tracker_status'		=> 1,
@@ -716,6 +717,7 @@ class m2_initial_data extends \phpbb\db\migration\migration
 			[
 				'tracker_id'			=> 2,
 				'tracker_name'			=> 'SECURITY_TRACKER',
+				'tracker_icon'			=> 'shield',
 				'tracker_email'			=> '',
 				'tracker_visibility'	=> 1,
 				'tracker_status'		=> 1,
@@ -724,6 +726,7 @@ class m2_initial_data extends \phpbb\db\migration\migration
 			[
 				'tracker_id'			=> 3,
 				'tracker_name'			=> 'BUG_TRACKER',
+				'tracker_icon'			=> 'bug',
 				'tracker_email'			=> '',
 				'tracker_visibility'	=> 0,
 				'tracker_status'		=> 1,
@@ -732,6 +735,7 @@ class m2_initial_data extends \phpbb\db\migration\migration
 			[
 				'tracker_id'			=> 4,
 				'tracker_name'			=> 'FEATURE_TRACKER',
+				'tracker_icon'			=> 'gift',
 				'tracker_email'			=> '',
 				'tracker_visibility'	=> 0,
 				'tracker_status'		=> 1,

--- a/styles/prosilver/template/event/overall_header_navigation_prepend.html
+++ b/styles/prosilver/template/event/overall_header_navigation_prepend.html
@@ -1,7 +1,7 @@
 {% if trackers %}
 <li id="trackers" class="dropdown-container responsive-menu" data-last-responsive="true">
 	<a href="#" class="dropdown-trigger">
-		<i class="icon fa-pencil fa-fw" aria-hidden="true"></i><span>{{ lang('TRACKERS') }}</span>
+		<i class="icon fa-files-o fa-fw" aria-hidden="true"></i><span>{{ lang('TRACKERS') }}</span>
 	</a>
 	<div class="dropdown">
 		<div class="pointer"><div class="pointer-inner"></div></div>

--- a/styles/prosilver/template/event/overall_header_navigation_prepend.html
+++ b/styles/prosilver/template/event/overall_header_navigation_prepend.html
@@ -1,7 +1,7 @@
 {% if trackers %}
 <li id="trackers" class="dropdown-container responsive-menu" data-last-responsive="true">
 	<a href="#" class="dropdown-trigger">
-		<i class="icon fa-bars fa-fw" aria-hidden="true"></i><span>{{ lang('TRACKERS') }}</span>
+		<i class="icon fa-pencil fa-fw" aria-hidden="true"></i><span>{{ lang('TRACKERS') }}</span>
 	</a>
 	<div class="dropdown">
 		<div class="pointer"><div class="pointer-inner"></div></div>
@@ -9,7 +9,7 @@
 			{% for tracker in trackers %}
 			<li>
 				<a href="{{ tracker.U_VIEWTRACKER }}" role="menuitem">
-					<i class="icon fa-file-o fa-fw icon-gray" aria-hidden="true"></i><span>{{ tracker.TRACKER_NAME }}</span>
+					<i class="icon fa-{{ tracker.TRACKER_ICON }} fa-fw" aria-hidden="true"></i><span>{{ tracker.TRACKER_NAME }}</span>
 				</a>
 			</li>
 			{% endfor %}


### PR DESCRIPTION
I've added a custom icon to all of the trackers so there is some visual difference between each one.

I've updated the migrations to ensure the icon is added during install for each tracker and with it being stored in the database, users could be allowed to edit this if they can manage each tracker further down the line.

Screenshot of what it looks like now:

![phpbbm-navbar-tracker-links-custom-icon](https://github.com/user-attachments/assets/0b5b4754-0231-43d9-85d2-6bd8757dcea2)

I also updated the language file to capitalise the `T` in trackers.